### PR TITLE
#2 but lint fix

### DIFF
--- a/src/components/ui/terminal/commandDecoder.tsx
+++ b/src/components/ui/terminal/commandDecoder.tsx
@@ -17,7 +17,7 @@ export const commandDecoder = (command: string): JSX.Element => {
   if (!foundCommand) {
     return (
       <CommandOutput>
-        Command `{command}` not found. Type "help" to see available commands.
+        Command `{command}` not found. Type &quot;help&quot; to see available commands.
       </CommandOutput>
     );
   }


### PR DESCRIPTION
This pull request includes a small change to the `commandDecoder` function in `src/components/ui/terminal/commandDecoder.tsx`. The change involves updating the error message for an unrecognized command to use the HTML entity for double quotes.

* [`src/components/ui/terminal/commandDecoder.tsx`](diffhunk://#diff-b1504706cb707658dc5425fe615593e10ba1d181b8668d2be93cead130be30bdL20-R20): Updated the error message for an unrecognized command to use the HTML entity for double quotes.